### PR TITLE
Added context manager for file object

### DIFF
--- a/imagebot.py
+++ b/imagebot.py
@@ -43,8 +43,9 @@ def upload():
     with requests.Session() as session:
         post = session.post(loginurl, data=logindata)  # Log in
         for i, filename in enumerate(ls):
-            file = {"image1": open(folder + "/" + filename, 'rb')}
-            r = session.post(uploadurl, files=file)
+            with open(folder + "/" + filename, 'rb') as picture
+                file = {"image1": picture}
+                r = session.post(uploadurl, files=file)
             if len(r.text) > 10000:
                 print("Error while uploading. Check credentials.")
                 return False


### PR DESCRIPTION
With statement (context manager) automatically closes the file when code within context is finished. File objects should be closed explicitly, especially if you open many simultaneously. Relying on garbage collection is risky when not all installations of python come with one that deals with files, and even then you have little control of when the file handles are freed up by garbage collection. Also easier to debug if error occurs when attempting file opening. See https://stackoverflow.com/questions/1834556/does-a-file-object-automatically-close-when-its-reference-count-hits-zero